### PR TITLE
Fix #46

### DIFF
--- a/src/main/java/shadows/fastbench/FastBench.java
+++ b/src/main/java/shadows/fastbench/FastBench.java
@@ -64,7 +64,7 @@ public class FastBench {
 	public static final ContainerType<ContainerFastBench> FAST_CRAFTING = null;
 
 	public FastBench() {
-		MinecraftForge.EVENT_BUS.register(this);
+		MinecraftForge.EVENT_BUS.register(new Events());
 		FMLJavaModLoadingContext.get().getModEventBus().register(this);
 		Configuration c = new Configuration(MODID);
 		removeRecipeBook = c.getBoolean("Remove Recipe Book", "general", true, "If the recipe book is removed from the game.  Server-enforced.");
@@ -95,35 +95,36 @@ public class FastBench {
 		PlaceboUtil.registerOverrideBlock(new BlockFastBench().setRegistryName("minecraft", "crafting_table"), MODID);
 	}
 
-	@SubscribeEvent
-	public void serverStartRemoval(FMLServerAboutToStartEvent e) {
-		if (removeRecipeBook) PROXY.replacePlayerList(e.getServer());
-	}
+	protected final class Events {
+		@SubscribeEvent
+		public void serverStartRemoval(FMLServerAboutToStartEvent e) {
+			if (removeRecipeBook) PROXY.replacePlayerList(e.getServer());
+		}
 
-	@SubscribeEvent
-	public void normalRemoval(EntityJoinWorldEvent e) {
-		if (removeRecipeBook) PROXY.deleteBook(e.getEntity());
-	}
+		@SubscribeEvent
+		public void normalRemoval(EntityJoinWorldEvent e) {
+			if (removeRecipeBook) PROXY.deleteBook(e.getEntity());
+		}
 
-	@SubscribeEvent
-	public void playerContainerStuff(EntityJoinWorldEvent e) {
-		Entity ent = e.getEntity();
-		if (ent instanceof PlayerEntity) {
-			PlayerContainer ctr = ((PlayerEntity) ent).container;
-			if (ctr.inventorySlots.get(0) instanceof SlotCraftingSucks) return; //Already replaced this one, do nothing.
-			CraftingInventoryExt inv = new CraftingInventoryExt(ctr, 2, 2);
-			ctr.craftMatrix = inv;
-			for (int i = 0; i < 5; i++) {
-				Slot s = ctr.inventorySlots.get(i);
-				if (i == 0) {
-					SlotCraftingSucks craftSlot = new SlotCraftingSucks(ctr.player, ctr.craftMatrix, ctr.craftResult, 0, 154, 28);
-					craftSlot.slotNumber = 0;
-					ctr.inventorySlots.set(0, craftSlot);
-				} else {
-					ObfuscationReflectionHelper.setPrivateValue(Slot.class, s, inv, "field_75224_c");
+		@SubscribeEvent
+		public void playerContainerStuff(EntityJoinWorldEvent e) {
+			Entity ent = e.getEntity();
+			if (ent instanceof PlayerEntity) {
+				PlayerContainer ctr = ((PlayerEntity) ent).container;
+				if (ctr.inventorySlots.get(0) instanceof SlotCraftingSucks) return; //Already replaced this one, do nothing.
+				CraftingInventoryExt inv = new CraftingInventoryExt(ctr, 2, 2);
+				ctr.craftMatrix = inv;
+				for (int i = 0; i < 5; i++) {
+					Slot s = ctr.inventorySlots.get(i);
+					if (i == 0) {
+						SlotCraftingSucks craftSlot = new SlotCraftingSucks(ctr.player, ctr.craftMatrix, ctr.craftResult, 0, 154, 28);
+						craftSlot.slotNumber = 0;
+						ctr.inventorySlots.set(0, craftSlot);
+					} else {
+						ObfuscationReflectionHelper.setPrivateValue(Slot.class, s, inv, "field_75224_c");
+					}
 				}
 			}
 		}
 	}
-
 }


### PR DESCRIPTION
Fixes #46 where mod fails to load in Forge 32.0.96+ due to error like `java.lang.IllegalArgumentException: Method public void shadows.fastbench.FastBench.normalRemoval(net.minecraftforge.event.entity.EntityJoinWorldEvent) has @SubscribeEvent annotation, but takes an argument that is not a subtype of the base type interface net.minecraftforge.fml.event.lifecycle.IModBusEvent: class net.minecraftforge.event.entity.EntityJoinWorldEvent`.

This PR moves event handlers for the Forge event bus into a nested inner class so that event handlers for the Mod event bus and Forge event bus are registered separately.