### PR TITLE
Update DedRecipeBook.java

### DIFF
--- a/src/main/java/shadows/fastbench/book/DedClientBook.java
+++ b/src/main/java/shadows/fastbench/book/DedClientBook.java
@@ -25,7 +25,7 @@ public class DedClientBook extends ClientRecipeBook {
 
 	@Override
 	public boolean isUnlocked(ResourceLocation p_226144_1_) {
-		return false;
+		return true;
 	}
 
 	@Override

--- a/src/main/java/shadows/fastbench/book/DedRecipeBook.java
+++ b/src/main/java/shadows/fastbench/book/DedRecipeBook.java
@@ -60,7 +60,7 @@ public class DedRecipeBook extends ServerRecipeBook {
 
 	@Override
 	public boolean isUnlocked(ResourceLocation p_226144_1_) {
-		return false;
+		return true;
 	}
 
 	@Override


### PR DESCRIPTION
Fix behavior ambiguation. 

All recipes seems unlocked from one menu and locked from another.

Both recipe by instance and by resource name should be either locked or unlocked.