### PR TITLE
Fix compatibility issue with Quark

### DIFF
--- a/src/main/java/shadows/fastbench/util/CraftResultSlotExt.java
+++ b/src/main/java/shadows/fastbench/util/CraftResultSlotExt.java
@@ -82,6 +82,7 @@ public class CraftResultSlotExt extends ResultSlot {
 	@Override
 	@SuppressWarnings("unchecked")
 	public ItemStack getItem() {
+		if (player.level.isClientSide) return super.getItem();
 		// Crafting Tweaks fakes 64x right click operations to right-click craft a stack to the "held" item, so we need to verify the recipe here.
 		Recipe<CraftingContainer> recipe = (Recipe<CraftingContainer>) this.inv.getRecipeUsed();
 		if (recipe != null && recipe.matches(this.craftSlots, player.level)) return super.getItem();


### PR DESCRIPTION
Quark adds `SlabToBlockRecipe` which enables to craft full blocks from slabs. The problem is on client side `SlabToBlockRecipe.matches` always return `false` so `CraftResultSlotExt` always show empty slot. This patch fixes this issue as well as keeping the functionality of preventing duplication bugs.