### PR TITLE
Fix client-side result slot rendering

### DIFF
--- a/src/main/java/dev/shadowsoffire/fastbench/util/CraftResultSlotExt.java
+++ b/src/main/java/dev/shadowsoffire/fastbench/util/CraftResultSlotExt.java
@@ -37,8 +37,12 @@ public class CraftResultSlotExt extends ResultSlot {
         this.inv.setItem(0, this.getItem().copy()); // https://github.com/Shadows-of-Fire/FastWorkbench/issues/62 - Vanilla's SWAP action will leak this stack here.
     }
 
-    @Override
-    public void set(ItemStack stack) {}
+@Override
+public void set(ItemStack stack) {
+    if (this.player.level().isClientSide) {
+        super.set(stack);
+    }
+}
 
     @Override
     protected void checkTakeAchievements(ItemStack stack) {


### PR DESCRIPTION
Allow CraftResultSlotExt#set to update the slot on the client side while keeping the server-side no-op behavior.

This fixes a visual issue where the crafting result slot can appear empty even though the result is valid and can still be clicked.